### PR TITLE
Refactor `FeedLoader` interface to directly return a list or throw

### DIFF
--- a/photofeed/src/commonMain/kotlin/com/asturiancoder/photofeed/feed/api/RemoteFeedRepository.kt
+++ b/photofeed/src/commonMain/kotlin/com/asturiancoder/photofeed/feed/api/RemoteFeedRepository.kt
@@ -1,6 +1,5 @@
 package com.asturiancoder.photofeed.feed.api
 
-import com.asturiancoder.photofeed.feed.api.model.HttpResponse
 import com.asturiancoder.photofeed.feed.feature.FeedLoader
 import com.asturiancoder.photofeed.feed.feature.FeedPhoto
 
@@ -14,19 +13,17 @@ class RemoteFeedRepository(
         object InvalidData : Error()
     }
 
-    override fun load(): Result<List<FeedPhoto>> {
-        return try {
-            map(client.get(url = url))
+    override fun load(): List<FeedPhoto> {
+        val response = try {
+            client.get(url = url)
         } catch (exception: Exception) {
-            Result.failure(Error.Connectivity)
+            throw Error.Connectivity
         }
-    }
 
-    private fun map(response: HttpResponse): Result<List<FeedPhoto>> {
         return try {
-            Result.success(FeedPhotosMapper.map(response))
+            FeedPhotosMapper.map(response)
         } catch (exception: Exception) {
-            Result.failure(Error.InvalidData)
+            throw Error.InvalidData
         }
     }
 }

--- a/photofeed/src/commonMain/kotlin/com/asturiancoder/photofeed/feed/cache/LocalFeedRepository.kt
+++ b/photofeed/src/commonMain/kotlin/com/asturiancoder/photofeed/feed/cache/LocalFeedRepository.kt
@@ -11,17 +11,13 @@ class LocalFeedRepository(
 
     private object InvalidCache : Exception()
 
-    override fun load(): Result<List<FeedPhoto>> {
-        return try {
-            val cache = store.retrieve()
+    override fun load(): List<FeedPhoto> {
+        val cache = store.retrieve()
 
-            if (cache != null && FeedCachePolicy.validate(cache.timestamp, currentTimestamp())) {
-                Result.success(cache.feed)
-            } else {
-                Result.success(emptyList())
-            }
-        } catch (exception: Exception) {
-            Result.failure(exception)
+        return if (cache != null && FeedCachePolicy.validate(cache.timestamp, currentTimestamp())) {
+            cache.feed
+        } else {
+            emptyList()
         }
     }
 

--- a/photofeed/src/commonMain/kotlin/com/asturiancoder/photofeed/feed/feature/FeedLoader.kt
+++ b/photofeed/src/commonMain/kotlin/com/asturiancoder/photofeed/feed/feature/FeedLoader.kt
@@ -1,5 +1,5 @@
 package com.asturiancoder.photofeed.feed.feature
 
 interface FeedLoader {
-    fun load(): Result<List<FeedPhoto>>
+    fun load(): List<FeedPhoto>
 }

--- a/photofeed/src/commonTest/kotlin/com/asturiancoder/photofeed/feed/api/RemoteFeedRepositoryTests.kt
+++ b/photofeed/src/commonTest/kotlin/com/asturiancoder/photofeed/feed/api/RemoteFeedRepositoryTests.kt
@@ -130,7 +130,7 @@ class RemoteFeedRepositoryTests {
     ) {
         action()
 
-        val receivedResult = sut.load()
+        val receivedResult = runCatching { sut.load() }
 
         assertEquals(
             expectedResult,
@@ -185,10 +185,13 @@ class RemoteFeedRepositoryTests {
         return Json.encodeToString(root)
     }
 
-    private class HttpClientSpy : HttpClient {
+    private inner class HttpClientSpy : HttpClient {
         val requestedUrls = mutableListOf<String>()
 
-        private val defaultResponse = HttpResponse(code = HttpStatusCode.OK, jsonString = "")
+        private val defaultResponse = HttpResponse(
+            code = HttpStatusCode.OK,
+            jsonString = makePhotosJson(listOf()),
+        )
         private var getResult: Result<HttpResponse> = Result.success(defaultResponse)
 
         override fun get(url: String): HttpResponse {

--- a/photofeed/src/commonTest/kotlin/com/asturiancoder/photofeed/feed/cache/LocalFeedRepositoryTests.kt
+++ b/photofeed/src/commonTest/kotlin/com/asturiancoder/photofeed/feed/cache/LocalFeedRepositoryTests.kt
@@ -294,7 +294,7 @@ class LocalFeedRepositoryTests {
     ) {
         onAction()
 
-        val receivedResult = load()
+        val receivedResult = runCatching { load() }
 
         assertEquals(
             expectedResult,


### PR DESCRIPTION
This modifies the return type of the `FeedLoader` abstraction to return a `List<FeedPhoto>` instead of the value wrapped in a `Result` type.